### PR TITLE
Feat  :  GetStudyMaterialListResponseDto 응답 데이터를 전달하기 위한 데이터 전송 객체생성

### DIFF
--- a/src/main/java/com/godlife_study/back/dto/response/studyService/GetStudyMaterialListResponseDto.java
+++ b/src/main/java/com/godlife_study/back/dto/response/studyService/GetStudyMaterialListResponseDto.java
@@ -1,0 +1,41 @@
+package com.godlife_study.back.dto.response.studyService;
+
+import com.godlife_study.back.common.object.StudyMaterialListItem;
+import com.godlife_study.back.dto.response.ResponseCode;
+import com.godlife_study.back.dto.response.ResponseDto;
+import com.godlife_study.back.dto.response.ResponseMessage;
+import com.godlife_study.back.repository.resultSet.StudyMaterialListResultSet;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+
+import lombok.Getter;
+
+@Getter
+public class GetStudyMaterialListResponseDto extends ResponseDto{
+
+    private List<StudyMaterialListItem> materialList;
+
+    private GetStudyMaterialListResponseDto(String code, String message, List<StudyMaterialListResultSet> resultSets){
+        super(code, message); 
+        this.materialList = StudyMaterialListItem.getMaterialList(resultSets);
+    }
+    
+    public static ResponseEntity<GetStudyMaterialListResponseDto> success(List<StudyMaterialListResultSet> resultSets){
+        GetStudyMaterialListResponseDto result = new GetStudyMaterialListResponseDto(ResponseCode.SUCCESS, ResponseMessage.SUCCESS, resultSets);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+    
+    public static ResponseEntity<ResponseDto> notExistUser(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+    
+    public static ResponseEntity<ResponseDto> notExistStudy(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_STUDY, ResponseMessage.NOT_EXIST_STUDY);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }      
+}


### PR DESCRIPTION
GetStudyMaterialListResponseDto  생성 및 스터디 자료 읽기시 실패와 성공에 대한 데이터 전송 객체생성 및 성공시  성공 코드 생성 및  DB 스터디 자료  테이블에 리스트 아이템으로 가져오기 실패시 각각의 에러에 따른 에러 코드 생성