### PR TITLE
Feat  :  PostStudyMaterialCommentRequestDto: 요청 데이터를 전달하기 위한 데이터 전송 객체생성,PostStudyMaterialResponseDto :응답 데이터를 전달하기 위한 데이터 전송 객체생성

### DIFF
--- a/src/main/java/com/godlife_study/back/dto/request/studyService/PostStudyMaterialCommentRequestDto.java
+++ b/src/main/java/com/godlife_study/back/dto/request/studyService/PostStudyMaterialCommentRequestDto.java
@@ -1,0 +1,17 @@
+package com.godlife_study.back.dto.request.studyService;
+
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostStudyMaterialCommentRequestDto {
+
+    @NotBlank
+    private String studyMaterialCommentContent;
+}

--- a/src/main/java/com/godlife_study/back/dto/response/studyService/PostStudyMaterialCommentResponseDto.java
+++ b/src/main/java/com/godlife_study/back/dto/response/studyService/PostStudyMaterialCommentResponseDto.java
@@ -1,0 +1,36 @@
+package com.godlife_study.back.dto.response.studyService;
+
+import com.godlife_study.back.dto.response.ResponseCode;
+import com.godlife_study.back.dto.response.ResponseDto;
+import com.godlife_study.back.dto.response.ResponseMessage;
+
+import lombok.Getter;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+
+
+@Getter
+public class PostStudyMaterialCommentResponseDto extends ResponseDto{
+
+    private PostStudyMaterialCommentResponseDto(String code, String message) {
+        super(code, message);
+    }
+    
+    public static ResponseEntity<PostStudyMaterialCommentResponseDto> success() {
+        PostStudyMaterialCommentResponseDto result = new PostStudyMaterialCommentResponseDto(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }    
+    
+    public static ResponseEntity<ResponseDto> notExistUser() {
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }    
+
+    public static ResponseEntity<ResponseDto> notExistStudy() {
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_STUDY, ResponseMessage.NOT_EXIST_STUDY);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+    
+}


### PR DESCRIPTION
PostStudyMaterialCommentRequestDto,PostStudyMaterialCommentResponseDto생성 및 스터디 자료 코멘트 작성시 실패와 성공에 대한 객체 생성 및 성공시 DB 스터디 자료  테이블에 추가시키기코멘트 작성시 실패와 성공에 대한 객체 생성 및 성공시 DB 스터디 자료  테이블에 추가시키기