### PR TITLE
Feat  : PatchStudyMaterialCommentRequestDto: 요청 데이터를 전달하기 위한 데이터 전송 객체생성,PatchStudyMaterialCommentResponseDto:응답 데이터를 전달하기 위한 데이터 전송 객체생성

### DIFF
--- a/src/main/java/com/godlife_study/back/dto/request/studyService/PatchStudyMaterialCommentRequestDto.java
+++ b/src/main/java/com/godlife_study/back/dto/request/studyService/PatchStudyMaterialCommentRequestDto.java
@@ -1,0 +1,20 @@
+package com.godlife_study.back.dto.request.studyService;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PatchStudyMaterialCommentRequestDto {
+    @NotNull
+    private int studyMaterialCommentNumber;
+
+    @NotBlank
+    private String studyMaterialCommentContent;    
+}

--- a/src/main/java/com/godlife_study/back/dto/response/studyService/PatchStudyMaterialCommentResponseDto.java
+++ b/src/main/java/com/godlife_study/back/dto/response/studyService/PatchStudyMaterialCommentResponseDto.java
@@ -1,0 +1,44 @@
+package com.godlife_study.back.dto.response.studyService;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.godlife_study.back.dto.response.ResponseCode;
+import com.godlife_study.back.dto.response.ResponseDto;
+import com.godlife_study.back.dto.response.ResponseMessage;
+
+public class PatchStudyMaterialCommentResponseDto extends ResponseDto{
+    private PatchStudyMaterialCommentResponseDto(String code, String message){
+        super(code, message);
+    }
+    
+    public static ResponseEntity<PatchStudyMaterialCommentResponseDto> success(){
+        PatchStudyMaterialCommentResponseDto result = new PatchStudyMaterialCommentResponseDto(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistUser(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistStudy(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_STUDY, ResponseMessage.NOT_EXIST_STUDY);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistMaterial(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_MATERIAL, ResponseMessage.NOT_EXIST_MATERIAL);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result); 
+    }   
+
+    public static ResponseEntity<ResponseDto> notExistMaterialCommment(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_MATERIAL_COMMENT, ResponseMessage.NOT_EXIST_MATERIAL_COMMENT);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result); 
+    }
+
+    public static  ResponseEntity<ResponseDto> noPermision(){
+        ResponseDto result = new ResponseDto(ResponseCode.NO_PERMISSION, ResponseMessage.NO_PERMISSION);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }    
+}


### PR DESCRIPTION


PatchStudyMaterialCommentRequestDto 서비스레이어에 데이터를 전달하기 위한 객체 생성,PatchStudyMaterialCommentResponseDto생성 및 스터디 자료 코멘트 수정시 실패와 성공에 대한 객체 생성 및 성공시 DB 스터디 자료  테이블에 정보 수정