### PR TITLE
Feat : studyService(service && serviceImplement) 스터디자료코멘트에   관한 정보를 patch시 Controller의 응답에 대한 데이터 반환

### DIFF
--- a/src/main/java/com/godlife_study/back/service/StudyService.java
+++ b/src/main/java/com/godlife_study/back/service/StudyService.java
@@ -3,6 +3,7 @@ package com.godlife_study.back.service;
 import org.springframework.http.ResponseEntity;
 
 import com.godlife_study.back.dto.request.studyService.PostStudyNoticeRequestDto;
+import com.godlife_study.back.dto.request.studyService.PatchStudyMaterialCommentRequestDto;
 import com.godlife_study.back.dto.request.studyService.PatchStudyNoticeRequestDto;
 
 import com.godlife_study.back.dto.response.studyService.GetStudyNoticeListResponseDto;
@@ -18,6 +19,7 @@ import com.godlife_study.back.dto.request.studyService.PostStudyMaterialCommentR
 import com.godlife_study.back.dto.request.studyService.PostStudyMaterialRequestDto;
 import com.godlife_study.back.dto.response.studyService.GetStudyTodoListResponseDto;
 import com.godlife_study.back.dto.response.studyService.GetStudyUserListResponseDto;
+import com.godlife_study.back.dto.response.studyService.PatchStudyMaterialCommentResponseDto;
 import com.godlife_study.back.dto.response.studyService.PostStudyTodoListResponseDto;
 import com.godlife_study.back.dto.response.studyService.PostStudyUserListResponseDto;
 import com.godlife_study.back.dto.response.studyService.PatchStudyTodoListResponseDto;
@@ -46,7 +48,7 @@ public interface StudyService {
 
     
     ResponseEntity<? super PostStudyMaterialCommentResponseDto> postMaterialComment(PostStudyMaterialCommentRequestDto dto, String userEmail,Integer studyNumber,Integer studyMaterialNumber);
-    
+    ResponseEntity<? super PatchStudyMaterialCommentResponseDto> patchMaterialComment(PatchStudyMaterialCommentRequestDto dto, String userEmail, Integer studyNumber, Integer studyMaterialNumber);    
 
 
 }

--- a/src/main/java/com/godlife_study/back/service/implement/StudyServiceImplement.java
+++ b/src/main/java/com/godlife_study/back/service/implement/StudyServiceImplement.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.godlife_study.back.dto.response.ResponseDto;
-
+import com.godlife_study.back.dto.request.studyService.PatchStudyMaterialCommentRequestDto;
 import com.godlife_study.back.dto.request.studyService.PatchStudyNoticeRequestDto;
 import com.godlife_study.back.dto.request.studyService.PostStudyNoticeRequestDto;
 
@@ -22,6 +22,7 @@ import com.godlife_study.back.dto.request.studyService.PostStudyMaterialCommentR
 import com.godlife_study.back.dto.request.studyService.PostStudyMaterialRequestDto;
 import com.godlife_study.back.dto.response.studyService.GetStudyTodoListResponseDto;
 import com.godlife_study.back.dto.response.studyService.GetStudyUserListResponseDto;
+import com.godlife_study.back.dto.response.studyService.PatchStudyMaterialCommentResponseDto;
 import com.godlife_study.back.dto.response.studyService.PostStudyTodoListResponseDto;
 import com.godlife_study.back.dto.response.studyService.PostStudyUserListResponseDto;
 import com.godlife_study.back.dto.response.studyService.PatchStudyTodoListResponseDto;
@@ -35,6 +36,7 @@ import com.godlife_study.back.entity.StudyMaterialEntity;
 import com.godlife_study.back.entity.StudyNoticeEntity;
 import com.godlife_study.back.entity.StudyTodoListEntity;
 import com.godlife_study.back.entity.StudyUserListEntity;
+import com.godlife_study.back.entity.UserEntity;
 import com.godlife_study.back.repository.UserRepository;
 import com.godlife_study.back.repository.StudyRepository;
 import com.godlife_study.back.repository.StudyMaterialCommentRepository;
@@ -439,6 +441,36 @@ public class StudyServiceImplement implements StudyService {
         }
 
         return PostStudyMaterialCommentResponseDto.success();
+    }
+
+    @Override
+    public ResponseEntity<? super PatchStudyMaterialCommentResponseDto> patchMaterialComment(PatchStudyMaterialCommentRequestDto dto, String userEmail, Integer studyNumber,Integer studyMaterialNumber) {
+        
+        try {
+            
+        UserEntity  userEntity = userRepository.findByUserEmail(userEmail);
+        if(userEntity == null) return PatchStudyMaterialCommentResponseDto.notExistUser();
+
+        StudyEntity studyEntity = studyRepository.findByStudyNumber(studyNumber);
+        if(studyEntity == null) return PatchStudyMaterialCommentResponseDto.notExistUser(); 
+            
+        StudyMaterialEntity  studyMaterialEntity = studyMaterialRepository.findByStudyMaterialNumber(studyMaterialNumber);            
+        if(studyMaterialEntity == null) return PatchStudyMaterialCommentResponseDto.notExistMaterial();        
+
+        StudyMaterialCommentEntity studyMaterialCommentEntity = studyMaterialCommentRepository.findByStudyMaterialCommentNumber(dto.getStudyMaterialCommentNumber());
+        if(studyMaterialCommentEntity == null) return PatchStudyMaterialCommentResponseDto.notExistMaterialCommment();
+
+        boolean equalWriter = studyMaterialCommentEntity.getUserEmail().equals(userEmail);
+        if(!equalWriter) return PatchStudyMaterialCommentResponseDto.noPermission();
+        
+        studyMaterialCommentEntity.patchMaterialComment(dto);
+        studyMaterialCommentRepository.save(studyMaterialCommentEntity);
+
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            return ResponseDto.databaseError(); 
+        }
+        return PatchStudyMaterialCommentResponseDto.success();
     }
     
     


### PR DESCRIPTION
 스터디자료 코멘트 리스트 수정시  patchMaterialComment()  이용한 Controller의 응답에 대한 데이터 비즈니스 로직에 따른 성공과 실패할 때 각각  응답에 대한 코드와 메시지 생성  성공시에는  db에 있는  스터디자료코멘트 테이블에서 스터디자료 코멘트 자료번호에 해당되는 정보를 찾아 스터디 자료 코멘트 댓글 수정