### PR TITLE
Feat  :  DeleteStudyMaterialCommentResponseDto응답 데이터를 전달하기 위한 데이터 전송 객체생성

### DIFF
--- a/src/main/java/com/godlife_study/back/dto/response/studyService/DeleteStudyMaterialCommentResponseDto.java
+++ b/src/main/java/com/godlife_study/back/dto/response/studyService/DeleteStudyMaterialCommentResponseDto.java
@@ -1,0 +1,50 @@
+package com.godlife_study.back.dto.response.studyService;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.godlife_study.back.dto.response.ResponseCode;
+import com.godlife_study.back.dto.response.ResponseDto;
+import com.godlife_study.back.dto.response.ResponseMessage;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteStudyMaterialCommentResponseDto extends ResponseDto{
+    
+    private DeleteStudyMaterialCommentResponseDto(String code,String message){
+        super(code, message);
+    }
+
+    public  static ResponseEntity<DeleteStudyMaterialCommentResponseDto> success() {
+        DeleteStudyMaterialCommentResponseDto result = new DeleteStudyMaterialCommentResponseDto(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistUser() {
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistStudy() {
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_STUDY, ResponseMessage.NOT_EXIST_STUDY);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistMaterial(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_MATERIAL, ResponseMessage.NOT_EXIST_MATERIAL);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result); 
+    }
+
+    public static ResponseEntity<ResponseDto> notExistComment() {
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_MATERIAL_COMMENT, ResponseMessage.NOT_EXIST_MATERIAL_COMMENT);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> noPermission() {
+        ResponseDto result = new ResponseDto(ResponseCode.NO_PERMISSION, ResponseMessage.NO_PERMISSION);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }    
+    
+}


### PR DESCRIPTION

DeleteStudyMaterialCommentResponseDto생성 및 스터디 자료 삭제시 실패와 성공에 대한 데이터 전송 객체(코드 및 메시지) 생성 및 성공시에만  DB 스터디 자료  테이블에 스터디 자료코멘트번호에 해당되는 정보 삭제하기